### PR TITLE
fix: avoid nil pointer when DB query fails

### DIFF
--- a/backend/lib/detail.go
+++ b/backend/lib/detail.go
@@ -108,12 +108,11 @@ AND dre.end_date <= $3
 	qsql = fmt.Sprintf("%s%s ORDER BY count DESC LIMIT %d", qsql, groupTerm, MAX_ROWS)
 
 	rows, errQuery := DB.Query(qsql, qargs...)
-	defer rows.Close()
-
 	if errQuery != nil {
 		log.Println("errQuery:  ", errQuery)
 		return results
 	}
+	defer rows.Close()
 
 	k := 0
 	for rows.Next() {

--- a/backend/lib/summary.go
+++ b/backend/lib/summary.go
@@ -89,12 +89,11 @@ GROUP BY source_ip, esp, domain_name, reverse_lookup,
 	qargs := []interface{}{domain, start, end}
 
 	rows, errQuery := DB.Query(qsql, qargs...)
-	defer rows.Close()
-
 	if errQuery != nil {
 		log.Println("errQuery:  ", errQuery)
 		return results, thecounts
 	}
+	defer rows.Close()
 
 	//----------------------------------------------------------------
 	// for each row, keep counts of the respective alignments:


### PR DESCRIPTION
## Summary
- check DB query errors before closing rows to prevent nil pointer panics

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a427e10730832eb97a439361c3f334